### PR TITLE
SWF-3869: Update all PLF components versions to 5.0.x-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -23,12 +23,12 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-parent</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
-   <groupId>org.gatein.pc</groupId>
+   <groupId>org.exoplatform.gatein.pc</groupId>
    <artifactId>pc-api</artifactId>
    <packaging>jar</packaging>
    <name>GateIn - Portlet Container (api)</name>

--- a/bridge/pom.xml
+++ b/bridge/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-parent</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>pc-bridge</artifactId>
@@ -11,7 +11,7 @@
 
    <dependencies>
       <dependency>
-         <groupId>org.gatein.pc</groupId>
+         <groupId>org.exoplatform.gatein.pc</groupId>
          <artifactId>pc-portlet</artifactId>
       </dependency>
       <dependency>

--- a/controller/pom.xml
+++ b/controller/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-parent</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>pc-controller</artifactId>
@@ -13,7 +13,7 @@
 
       <!-- Internal dependencies -->
       <dependency>
-         <groupId>org.gatein.pc</groupId>
+         <groupId>org.exoplatform.gatein.pc</groupId>
          <artifactId>pc-portlet</artifactId>
       </dependency>
 
@@ -36,7 +36,7 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>org.gatein.pc</groupId>
+         <groupId>org.exoplatform.gatein.pc</groupId>
          <artifactId>pc-portlet</artifactId>
          <type>test-jar</type>
          <scope>test</scope>

--- a/embed/pom.xml
+++ b/embed/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-parent</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>pc-embed</artifactId>
@@ -11,7 +11,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-portlet</artifactId>
     </dependency>
     <dependency>

--- a/federation/pom.xml
+++ b/federation/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-parent</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>pc-federation</artifactId>
@@ -11,7 +11,7 @@
 
    <dependencies>
       <dependency>
-         <groupId>org.gatein.pc</groupId>
+         <groupId>org.exoplatform.gatein.pc</groupId>
          <artifactId>pc-portlet</artifactId>
       </dependency>
 
@@ -27,7 +27,7 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>org.gatein.pc</groupId>
+         <groupId>org.exoplatform.gatein.pc</groupId>
          <artifactId>pc-portlet</artifactId>
          <type>test-jar</type>
          <scope>test</scope>

--- a/jsr168api/pom.xml
+++ b/jsr168api/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-parent</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>pc-jsr168api</artifactId>

--- a/management/pom.xml
+++ b/management/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-parent</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>pc-management</artifactId>
@@ -11,7 +11,7 @@
 
    <dependencies>
       <dependency>
-         <groupId>org.gatein.pc</groupId>
+         <groupId>org.exoplatform.gatein.pc</groupId>
          <artifactId>pc-portlet</artifactId>
       </dependency>
    </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,9 @@
       <version>1.3.0.Final</version>
    </parent>
 
-   <groupId>org.gatein.pc</groupId>
+   <groupId>org.exoplatform.gatein.pc</groupId>
    <artifactId>pc-parent</artifactId>
-   <version>2.7.x-PLF-SNAPSHOT</version>
+   <version>5.0.x-SNAPSHOT</version>
    <packaging>pom</packaging>
 
    <name>GateIn - Portlet Container</name>
@@ -127,53 +127,53 @@
 
          <!-- Internal dependencies -->
          <dependency>
-            <groupId>org.gatein.pc</groupId>
+            <groupId>org.exoplatform.gatein.pc</groupId>
             <artifactId>pc-portlet</artifactId>
             <version>${project.version}</version>
          </dependency>
          <dependency>
-            <groupId>org.gatein.pc</groupId>
+            <groupId>org.exoplatform.gatein.pc</groupId>
             <artifactId>pc-portlet</artifactId>
             <type>test-jar</type>
             <version>${project.version}</version>
          </dependency>
          <dependency>
-            <groupId>org.gatein.pc</groupId>
+            <groupId>org.exoplatform.gatein.pc</groupId>
             <artifactId>pc-portlet</artifactId>
             <type>test-jar</type>
             <classifier>tests</classifier>
             <version>${project.version}</version>
          </dependency>
          <dependency>
-            <groupId>org.gatein.pc</groupId>
+            <groupId>org.exoplatform.gatein.pc</groupId>
             <artifactId>pc-controller</artifactId>
             <version>${project.version}</version>
          </dependency>
          <dependency>
-            <groupId>org.gatein.pc</groupId>
+            <groupId>org.exoplatform.gatein.pc</groupId>
             <artifactId>pc-api</artifactId>
             <version>${project.version}</version>
          </dependency>
          <dependency>
-            <groupId>org.gatein.pc</groupId>
+            <groupId>org.exoplatform.gatein.pc</groupId>
             <artifactId>pc-test-core</artifactId>
             <version>${project.version}</version>
          </dependency>
          <dependency>
-           <groupId>org.gatein.pc</groupId>
+           <groupId>org.exoplatform.gatein.pc</groupId>
            <artifactId>pc-test-core</artifactId>
            <version>${project.version}</version>
            <type>test-jar</type>
          </dependency>
          <dependency>
-           <groupId>org.gatein.pc</groupId>
+           <groupId>org.exoplatform.gatein.pc</groupId>
            <artifactId>pc-test-core</artifactId>
            <version>${project.version}</version>
            <type>test-jar</type>
            <classifier>test-sources</classifier>
          </dependency>
          <dependency>
-            <groupId>org.gatein.pc</groupId>
+            <groupId>org.exoplatform.gatein.pc</groupId>
             <artifactId>pc-test-servers-jboss7-dependencies</artifactId>
             <version>${project.version}</version>
          </dependency>

--- a/portlet/pom.xml
+++ b/portlet/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-parent</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>pc-portlet</artifactId>
@@ -11,7 +11,7 @@
 
    <dependencies>
       <dependency>
-         <groupId>org.gatein.pc</groupId>
+         <groupId>org.exoplatform.gatein.pc</groupId>
          <artifactId>pc-api</artifactId>
       </dependency>
       <dependency>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -23,9 +23,9 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-parent</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>pc-samples</artifactId>

--- a/test/core/pom.xml
+++ b/test/core/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-test</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>pc-test-core</artifactId>
@@ -17,15 +17,15 @@
          <artifactId>common-logging</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.gatein.pc</groupId>
+         <groupId>org.exoplatform.gatein.pc</groupId>
          <artifactId>pc-controller</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.gatein.pc</groupId>
+         <groupId>org.exoplatform.gatein.pc</groupId>
          <artifactId>pc-portlet</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.gatein.pc</groupId>
+         <groupId>org.exoplatform.gatein.pc</groupId>
          <artifactId>pc-api</artifactId>
       </dependency>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-parent</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>pc-test</artifactId>

--- a/test/servers/glassfish3/pom.xml
+++ b/test/servers/glassfish3/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-test-servers</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>pc-test-servers-glassfish3</artifactId>
@@ -13,11 +13,11 @@
 
        <!-- -->
       <dependency>
-         <groupId>org.gatein.pc</groupId>
+         <groupId>org.exoplatform.gatein.pc</groupId>
          <artifactId>pc-test-core</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.gatein.pc</groupId>
+         <groupId>org.exoplatform.gatein.pc</groupId>
          <artifactId>pc-test-core</artifactId>
          <type>test-jar</type>
          <classifier>test-sources</classifier>

--- a/test/servers/jboss7/dependencies/pom.xml
+++ b/test/servers/jboss7/dependencies/pom.xml
@@ -1,9 +1,9 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-test-servers-jboss7</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>pc-test-servers-jboss7-dependencies</artifactId>
@@ -17,11 +17,11 @@
       <artifactId>portlet-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-portlet</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-controller</artifactId>
     </dependency>
     <dependency>

--- a/test/servers/jboss7/pom.xml
+++ b/test/servers/jboss7/pom.xml
@@ -1,9 +1,9 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-test-servers</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>pc-test-servers-jboss7</artifactId>

--- a/test/servers/jboss7/run/pom.xml
+++ b/test/servers/jboss7/run/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-test-servers-jboss7</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>pc-test-servers-jboss7-run</artifactId>
@@ -13,11 +13,11 @@
 
       <!-- -->
       <dependency>
-         <groupId>org.gatein.pc</groupId>
+         <groupId>org.exoplatform.gatein.pc</groupId>
          <artifactId>pc-test-core</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.gatein.pc</groupId>
+         <groupId>org.exoplatform.gatein.pc</groupId>
          <artifactId>pc-test-core</artifactId>
          <type>test-jar</type>
          <classifier>test-sources</classifier>

--- a/test/servers/jetty7/pom.xml
+++ b/test/servers/jetty7/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-test-servers</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>pc-test-servers-jetty7</artifactId>
@@ -13,11 +13,11 @@
 
       <!-- -->
      <dependency>
-       <groupId>org.gatein.pc</groupId>
+       <groupId>org.exoplatform.gatein.pc</groupId>
        <artifactId>pc-test-core</artifactId>
      </dependency>
      <dependency>
-       <groupId>org.gatein.pc</groupId>
+       <groupId>org.exoplatform.gatein.pc</groupId>
        <artifactId>pc-test-core</artifactId>
        <type>test-jar</type>
        <classifier>test-sources</classifier>

--- a/test/servers/pom.xml
+++ b/test/servers/pom.xml
@@ -1,9 +1,9 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-test</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>pc-test-servers</artifactId>
@@ -35,7 +35,7 @@
              <configuration>
                <artifactItems>
                  <artifactItem>
-                   <groupId>org.gatein.pc</groupId>
+                   <groupId>org.exoplatform.gatein.pc</groupId>
                    <artifactId>pc-test-core</artifactId>
                    <type>test-jar</type>
                    <classifier>test-sources</classifier>
@@ -55,7 +55,7 @@
              <configuration>
                <artifactItems>
                  <artifactItem>
-                   <groupId>org.gatein.pc</groupId>
+                   <groupId>org.exoplatform.gatein.pc</groupId>
                    <artifactId>pc-test-core</artifactId>
                    <type>test-jar</type>
                  </artifactItem>

--- a/test/servers/tomcat7/pom.xml
+++ b/test/servers/tomcat7/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.pc</groupId>
+      <groupId>org.exoplatform.gatein.pc</groupId>
       <artifactId>pc-test-servers</artifactId>
-      <version>2.7.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>pc-test-servers-tomcat7</artifactId>
@@ -18,11 +18,11 @@
 
       <!-- -->
       <dependency>
-        <groupId>org.gatein.pc</groupId>
+        <groupId>org.exoplatform.gatein.pc</groupId>
         <artifactId>pc-test-core</artifactId>
       </dependency>
       <dependency>
-        <groupId>org.gatein.pc</groupId>
+        <groupId>org.exoplatform.gatein.pc</groupId>
         <artifactId>pc-test-core</artifactId>
         <type>test-jar</type>
         <classifier>test-sources</classifier>


### PR DESCRIPTION
  * Maven groupId moved from org.gatein.pc to org.exoplatform.gatein.pc
  * Java packages are still org.gatein.pc

(see SWF-3871 for gatein projects)