### PR TITLE
PLF-7090 : upgrade to Tomcat 8.5

### DIFF
--- a/bridge/src/main/java/org/gatein/pc/bridge/BridgeResponse.java
+++ b/bridge/src/main/java/org/gatein/pc/bridge/BridgeResponse.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 import javax.portlet.PortletResponse;
 import javax.portlet.RenderResponse;
 import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponseWrapper;
@@ -165,6 +166,16 @@ public class BridgeResponse extends HttpServletResponseWrapper
                public void write(int b) throws IOException
                {
                   out.write(b);
+               }
+
+               @Override
+               public boolean isReady() {
+                  return false;
+               }
+
+               @Override
+               public void setWriteListener(WriteListener writeListener) {
+                  // Ignore
                }
             };
          }

--- a/embed/pom.xml
+++ b/embed/pom.xml
@@ -71,7 +71,7 @@
     <!-- Arquillian container -->
     <dependency>
       <groupId>org.jboss.arquillian.container</groupId>
-      <artifactId>arquillian-tomcat-embedded-7</artifactId>
+      <artifactId>arquillian-tomcat-embedded-8</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -82,11 +82,6 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-jasper</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomcat.embed</groupId>
-      <artifactId>tomcat-embed-logging-juli</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -108,22 +103,12 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.extension</groupId>
-      <artifactId>arquillian-drone-selenium</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.arquillian.extension</groupId>
       <artifactId>arquillian-drone-webdriver</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>selenium-htmlunit-driver</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/embed/src/test/java/org/gatein/pc/embed/AbstractTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/AbstractTestCase.java
@@ -74,6 +74,7 @@ public abstract class AbstractTestCase
          "xmlns=\"http://java.sun.com/xml/ns/javaee\"\n" +
          "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
          "xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n" +
+         "metadata-complete=\"true\"\n" +
          "version=\"3.0\">" +
          "<servlet>\n" +
          "<servlet-name>EmbedServlet</servlet-name>\n" +
@@ -86,6 +87,11 @@ public abstract class AbstractTestCase
          "</servlet-mapping>\n" +
          "</web-app>\n").getBytes()));
       war.addAsWebInfResource(new ByteArrayAsset(descriptor.getBytes()), "portlet.xml");
+      war.addAsManifestResource(new ByteArrayAsset(("" +
+              "<Context>\n" +
+              "<JarScanner scanManifest=\"false\">\n" +
+              "</JarScanner>\n" +
+              "</Context>\n").getBytes()), "context.xml");
       return war;
    }
 

--- a/embed/src/test/java/org/gatein/pc/embed/action/ActionTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/action/ActionTestCase.java
@@ -37,6 +37,8 @@ import java.net.URL;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class ActionTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -48,6 +50,7 @@ public class ActionTestCase extends AbstractTestCase
    WebDriver driver;
 
    @Test
+   @RunAsClient
    @InSequence(0)
    public void init()
    {
@@ -57,7 +60,7 @@ public class ActionTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(1)
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, ActionPortlet.class);
       driver.get(url.toString());
@@ -66,6 +69,7 @@ public class ActionTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(2)
    public void testInvoked()
    {

--- a/embed/src/test/java/org/gatein/pc/embed/actionbinary/ActionBinaryTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/actionbinary/ActionBinaryTestCase.java
@@ -40,6 +40,8 @@ import java.net.URL;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class ActionBinaryTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -53,7 +55,7 @@ public class ActionBinaryTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(0)
-   public void display(@ArquillianResource URL deploymentURL) throws Exception
+   public void display() throws Exception
    {
       URL url = renderURL(deploymentURL, ActionBinaryPortlet.class);
       driver.get(url.toString());
@@ -72,6 +74,7 @@ public class ActionBinaryTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(1)
    public void check() throws Exception
    {

--- a/embed/src/test/java/org/gatein/pc/embed/actioncookie/ActionCookieTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/actioncookie/ActionCookieTestCase.java
@@ -38,6 +38,8 @@ import java.util.Map;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class ActionCookieTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment()
    public static WebArchive deployment()
@@ -50,7 +52,7 @@ public class ActionCookieTestCase extends AbstractTestCase
 
    @Test
    @RunAsClient
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, ActionCookiePortlet.class);
       driver.get(url.toString());

--- a/embed/src/test/java/org/gatein/pc/embed/actionerror/ActionErrorTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/actionerror/ActionErrorTestCase.java
@@ -38,6 +38,8 @@ import java.net.URL;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class ActionErrorTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -50,7 +52,7 @@ public class ActionErrorTestCase extends AbstractTestCase
 
    @Test
    @RunAsClient
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, ActionErrorPortlet.class);
       driver.get(url.toString());

--- a/embed/src/test/java/org/gatein/pc/embed/actionform/ActionFormParameterTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/actionform/ActionFormParameterTestCase.java
@@ -41,6 +41,8 @@ import java.util.Collections;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class ActionFormParameterTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -65,6 +67,7 @@ public class ActionFormParameterTestCase extends AbstractTestCase
    WebDriver driver;
 
    @Test
+   @RunAsClient
    @InSequence(0)
    public void init()
    {
@@ -79,13 +82,14 @@ public class ActionFormParameterTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(1)
-   public void display(@ArquillianResource URL deploymentURL) throws Exception
+   public void display() throws Exception
    {
       URL url = renderURL(deploymentURL, ActionFormParameterPortlet.class);
       driver.get(url.toString());
    }
 
    @Test
+   @RunAsClient
    @InSequence(2)
    public void testDisplay()
    {
@@ -107,6 +111,7 @@ public class ActionFormParameterTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(4)
    public void testInteraction()
    {

--- a/embed/src/test/java/org/gatein/pc/embed/actionheader/ActionHeaderTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/actionheader/ActionHeaderTestCase.java
@@ -38,6 +38,8 @@ import java.util.Map;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class ActionHeaderTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment()
    public static WebArchive deployment()
@@ -50,7 +52,7 @@ public class ActionHeaderTestCase extends AbstractTestCase
 
    @Test
    @RunAsClient
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, ActionHeaderPortlet.class);
       driver.get(url.toString());

--- a/embed/src/test/java/org/gatein/pc/embed/actionsetparameter/ActionSetParameterTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/actionsetparameter/ActionSetParameterTestCase.java
@@ -41,6 +41,8 @@ import java.util.Collections;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class ActionSetParameterTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -65,6 +67,7 @@ public class ActionSetParameterTestCase extends AbstractTestCase
    WebDriver driver;
 
    @Test
+   @RunAsClient
    @InSequence(0)
    public void init()
    {
@@ -76,13 +79,14 @@ public class ActionSetParameterTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(1)
-   public void display(@ArquillianResource URL deploymentURL) throws Exception
+   public void display() throws Exception
    {
       URL url = renderURL(deploymentURL, ActionSetParameterPortlet.class);
       driver.get(url.toString());
    }
 
    @Test
+   @RunAsClient
    @InSequence(2)
    public void testAfterDisplay()
    {
@@ -101,6 +105,7 @@ public class ActionSetParameterTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(4)
    public void testInvoked()
    {

--- a/embed/src/test/java/org/gatein/pc/embed/actionurlparameter/ActionURLParameterTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/actionurlparameter/ActionURLParameterTestCase.java
@@ -41,6 +41,8 @@ import java.util.Collections;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class ActionURLParameterTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -65,6 +67,7 @@ public class ActionURLParameterTestCase extends AbstractTestCase
    WebDriver driver;
 
    @Test
+   @RunAsClient
    @InSequence(0)
    public void init()
    {
@@ -79,13 +82,14 @@ public class ActionURLParameterTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(1)
-   public void display(@ArquillianResource URL deploymentURL) throws Exception
+   public void display() throws Exception
    {
       URL url = renderURL(deploymentURL, ActionURLParameterPortlet.class);
       driver.get(url.toString());
    }
 
    @Test
+   @RunAsClient
    @InSequence(2)
    public void testDisplay()
    {
@@ -107,6 +111,7 @@ public class ActionURLParameterTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(4)
    public void testInteraction()
    {

--- a/embed/src/test/java/org/gatein/pc/embed/contextpath/ContextPathTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/contextpath/ContextPathTestCase.java
@@ -34,6 +34,8 @@ import java.net.URL;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class ContextPathTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -44,7 +46,7 @@ public class ContextPathTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(0)
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, ContextPathPortlet.class);
       HttpURLConnection conn = (HttpURLConnection)url.openConnection();
@@ -53,6 +55,7 @@ public class ContextPathTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(1)
    public void testContextPath()
    {

--- a/embed/src/test/java/org/gatein/pc/embed/emptypath/EmptyPathTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/emptypath/EmptyPathTestCase.java
@@ -36,6 +36,8 @@ import java.net.URL;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class EmptyPathTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -47,7 +49,7 @@ public class EmptyPathTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(0)
-   public void init(@ArquillianResource URL deploymentURL) throws Exception
+   public void init() throws Exception
    {
       URL u = deploymentURL.toURI().resolve("embed/").toURL();
       HttpURLConnection conn = (HttpURLConnection)u.openConnection();

--- a/embed/src/test/java/org/gatein/pc/embed/event/EventTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/event/EventTestCase.java
@@ -38,6 +38,8 @@ import java.net.URL;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class EventTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -64,6 +66,7 @@ public class EventTestCase extends AbstractTestCase
    WebDriver driver;
 
    @Test
+   @RunAsClient
    @InSequence(0)
    public void init()
    {
@@ -75,7 +78,7 @@ public class EventTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(1)
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, EventPortlet.class);
       driver.get(url.toString());
@@ -84,6 +87,7 @@ public class EventTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(2)
    public void testInvoked()
    {

--- a/embed/src/test/java/org/gatein/pc/embed/eventoverflow/EventOverflowTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/eventoverflow/EventOverflowTestCase.java
@@ -38,6 +38,8 @@ import java.net.URL;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class EventOverflowTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -64,6 +66,7 @@ public class EventOverflowTestCase extends AbstractTestCase
    WebDriver driver;
 
    @Test
+   @RunAsClient
    @InSequence(0)
    public void init()
    {
@@ -73,7 +76,7 @@ public class EventOverflowTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(1)
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, EventOverflowPortlet.class);
       driver.get(url.toString());
@@ -84,6 +87,7 @@ public class EventOverflowTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(2)
    public void testInvoked()
    {

--- a/embed/src/test/java/org/gatein/pc/embed/eventsetparameter/EventSetParameterTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/eventsetparameter/EventSetParameterTestCase.java
@@ -41,6 +41,8 @@ import java.util.Collections;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class EventSetParameterTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -72,6 +74,7 @@ public class EventSetParameterTestCase extends AbstractTestCase
    WebDriver driver;
 
    @Test
+   @RunAsClient
    @InSequence(0)
    public void init()
    {
@@ -83,13 +86,14 @@ public class EventSetParameterTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(1)
-   public void display(@ArquillianResource URL deploymentURL) throws Exception
+   public void display() throws Exception
    {
       URL url = renderURL(deploymentURL, EventSetParameterPortlet.class);
       driver.get(url.toString());
    }
 
    @Test
+   @RunAsClient
    @InSequence(2)
    public void testAfterDisplay()
    {
@@ -108,6 +112,7 @@ public class EventSetParameterTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(4)
    public void testInvoked()
    {

--- a/embed/src/test/java/org/gatein/pc/embed/htmlheader/HtmlHeaderTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/htmlheader/HtmlHeaderTestCase.java
@@ -36,6 +36,8 @@ import java.net.URL;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class HtmlHeaderTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment()
    public static WebArchive deployment()
@@ -48,12 +50,11 @@ public class HtmlHeaderTestCase extends AbstractTestCase
 
    @Test
    @RunAsClient
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, HtmlHeaderPortlet.class);
       driver.get(url.toString());
-      WebElement title = driver.findElement(By.tagName("title"));
-      Assert.assertEquals("_title_", title.getText());
+      Assert.assertEquals("_title_", driver.getTitle());
       WebElement script = driver.findElement(By.tagName("script"));
       Assert.assertTrue(script.getAttribute("src").endsWith("_src_"));
       Assert.assertEquals("_type_", script.getAttribute("type"));
@@ -70,6 +71,6 @@ public class HtmlHeaderTestCase extends AbstractTestCase
       WebElement style = driver.findElement(By.tagName("style"));
       Assert.assertEquals("_type_", style.getAttribute("type"));
       Assert.assertEquals("_media_", style.getAttribute("media"));
-      Assert.assertEquals("_style_", style.getText());
+      Assert.assertEquals("_style_", style.getAttribute("textContent"));
    }
 }

--- a/embed/src/test/java/org/gatein/pc/embed/lifecycle/LifeCycleTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/lifecycle/LifeCycleTestCase.java
@@ -44,6 +44,7 @@ public class LifeCycleTestCase extends AbstractTestCase
 
    @Test
    @InSequence(0)
+   @RunAsClient
    public void testBefore()
    {
       Assert.assertFalse(LifeCyclePortlet.started);
@@ -59,6 +60,7 @@ public class LifeCycleTestCase extends AbstractTestCase
 
    @Test
    @InSequence(2)
+   @RunAsClient
    public void testDeployed()
    {
       Assert.assertTrue(LifeCyclePortlet.started);
@@ -74,6 +76,7 @@ public class LifeCycleTestCase extends AbstractTestCase
 
    @Test
    @InSequence(4)
+   @RunAsClient
    public void testUndeployed()
    {
       Assert.assertFalse(LifeCyclePortlet.started);

--- a/embed/src/test/java/org/gatein/pc/embed/publicrenderparameter/PublicRenderParameterTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/publicrenderparameter/PublicRenderParameterTestCase.java
@@ -39,6 +39,8 @@ import java.util.Collections;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class PublicRenderParameterTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    static int phase;
 
@@ -73,6 +75,7 @@ public class PublicRenderParameterTestCase extends AbstractTestCase
    WebDriver driver;
 
    @Test
+   @RunAsClient
    public void init()
    {
       phase = 0;
@@ -81,13 +84,14 @@ public class PublicRenderParameterTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(0)
-   public void testSetPortlet1(@ArquillianResource URL deploymentURL) throws Exception
+   public void testSetPortlet1() throws Exception
    {
       URL url = renderURL(deploymentURL, PublicRenderParameterPortlet1.class, PublicRenderParameterPortlet2.class);
       driver.get(url.toString());
    }
 
    @Test
+   @RunAsClient
    @InSequence(1)
    public void testNone()
    {
@@ -106,6 +110,7 @@ public class PublicRenderParameterTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(3)
    public void testPortlet1()
    {
@@ -126,6 +131,7 @@ public class PublicRenderParameterTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(5)
    public void testPortlet2()
    {

--- a/embed/src/test/java/org/gatein/pc/embed/render/RenderTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/render/RenderTestCase.java
@@ -34,6 +34,8 @@ import java.net.URL;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class RenderTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -43,7 +45,7 @@ public class RenderTestCase extends AbstractTestCase
 
    @Test
    @RunAsClient
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, RenderPortlet.class);
       HttpURLConnection conn = (HttpURLConnection)url.openConnection();

--- a/embed/src/test/java/org/gatein/pc/embed/rendercookie/RenderCookieTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/rendercookie/RenderCookieTestCase.java
@@ -34,6 +34,8 @@ import java.util.Map;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class RenderCookieTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment()
    public static WebArchive deployment()
@@ -43,7 +45,7 @@ public class RenderCookieTestCase extends AbstractTestCase
 
    @Test
    @RunAsClient
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, RenderCookiePortlet.class);
       HttpURLConnection conn = (HttpURLConnection)url.openConnection();

--- a/embed/src/test/java/org/gatein/pc/embed/rendererror/RenderErrorTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/rendererror/RenderErrorTestCase.java
@@ -34,6 +34,8 @@ import java.net.URL;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class RenderErrorTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -43,7 +45,7 @@ public class RenderErrorTestCase extends AbstractTestCase
 
    @Test
    @RunAsClient
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, RenderErrorPortlet.class);
       HttpURLConnection conn = (HttpURLConnection)url.openConnection();

--- a/embed/src/test/java/org/gatein/pc/embed/renderformparameter/RenderFormParameterTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/renderformparameter/RenderFormParameterTestCase.java
@@ -39,6 +39,8 @@ import java.net.URL;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class RenderFormParameterTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -63,6 +65,7 @@ public class RenderFormParameterTestCase extends AbstractTestCase
    WebDriver driver;
 
    @Test
+   @RunAsClient
    @InSequence(0)
    public void init()
    {
@@ -74,13 +77,14 @@ public class RenderFormParameterTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(1)
-   public void display(@ArquillianResource URL deploymentURL) throws Exception
+   public void display() throws Exception
    {
       URL url = renderURL(deploymentURL, RenderFormParameterPortlet.class);
       driver.get(url.toString());
    }
 
    @Test
+   @RunAsClient
    @InSequence(2)
    public void testAfterDispay()
    {
@@ -99,6 +103,7 @@ public class RenderFormParameterTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(4)
    public void testInvoked()
    {

--- a/embed/src/test/java/org/gatein/pc/embed/renderheader/RenderHeaderTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/renderheader/RenderHeaderTestCase.java
@@ -34,6 +34,8 @@ import java.util.Map;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class RenderHeaderTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment()
    public static WebArchive deployment()
@@ -43,7 +45,7 @@ public class RenderHeaderTestCase extends AbstractTestCase
 
    @Test
    @RunAsClient
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, RenderHeaderPortlet.class);
       HttpURLConnection conn = (HttpURLConnection)url.openConnection();

--- a/embed/src/test/java/org/gatein/pc/embed/renderparameter/RenderParameterTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/renderparameter/RenderParameterTestCase.java
@@ -39,6 +39,8 @@ import java.util.Collections;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class RenderParameterTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    static int phase;
 
@@ -52,6 +54,7 @@ public class RenderParameterTestCase extends AbstractTestCase
    WebDriver driver;
 
    @Test
+   @RunAsClient
    public void init()
    {
       phase = 0;
@@ -60,13 +63,14 @@ public class RenderParameterTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(0)
-   public void testSetPortlet1(@ArquillianResource URL deploymentURL) throws Exception
+   public void testSetPortlet1() throws Exception
    {
       URL url = renderURL(deploymentURL, RenderParameterPortlet1.class, RenderParameterPortlet2.class);
       driver.get(url.toString());
    }
 
    @Test
+   @RunAsClient
    @InSequence(1)
    public void testNone()
    {
@@ -85,6 +89,7 @@ public class RenderParameterTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(3)
    public void testPortlet1()
    {
@@ -104,6 +109,7 @@ public class RenderParameterTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(5)
    public void testPortlet2()
    {

--- a/embed/src/test/java/org/gatein/pc/embed/renderurl/RenderURLTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/renderurl/RenderURLTestCase.java
@@ -37,6 +37,8 @@ import java.net.URL;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class RenderURLTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -48,6 +50,7 @@ public class RenderURLTestCase extends AbstractTestCase
    WebDriver driver;
 
    @Test
+   @RunAsClient
    @InSequence(0)
    public void init()
    {
@@ -57,7 +60,7 @@ public class RenderURLTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(1)
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, RenderURLPortlet.class);
       driver.get(url.toString());
@@ -66,6 +69,7 @@ public class RenderURLTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(2)
    public void testInvoked()
    {

--- a/embed/src/test/java/org/gatein/pc/embed/renderurlparameter/RenderURLParameterTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/renderurlparameter/RenderURLParameterTestCase.java
@@ -41,6 +41,8 @@ import java.util.Collections;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class RenderURLParameterTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -65,6 +67,7 @@ public class RenderURLParameterTestCase extends AbstractTestCase
    WebDriver driver;
 
    @Test
+   @RunAsClient
    @InSequence(0)
    public void init()
    {
@@ -76,13 +79,14 @@ public class RenderURLParameterTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(1)
-   public void display(@ArquillianResource URL deploymentURL) throws Exception
+   public void display() throws Exception
    {
       URL url = renderURL(deploymentURL, RenderURLParameterPortlet.class);
       driver.get(url.toString());
    }
 
    @Test
+   @RunAsClient
    @InSequence(2)
    public void testAfterDispay()
    {
@@ -101,6 +105,7 @@ public class RenderURLParameterTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(4)
    public void testInvoked()
    {

--- a/embed/src/test/java/org/gatein/pc/embed/resource/ResourceTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/resource/ResourceTestCase.java
@@ -40,6 +40,8 @@ import java.util.Map;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class ResourceTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -53,7 +55,7 @@ public class ResourceTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(0)
-   public void init(@ArquillianResource URL deploymentURL) throws Exception
+   public void init() throws Exception
    {
       Assert.assertEquals(0, ResourcePortlet.count);
       URL url = deploymentURL.toURI().resolve("embed/ResourcePortlet").toURL();
@@ -70,6 +72,7 @@ public class ResourceTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(2)
    public void testParams()
    {
@@ -96,6 +99,7 @@ public class ResourceTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(4)
    public void testInvoked()
    {

--- a/embed/src/test/java/org/gatein/pc/embed/resourcebinary/ResourceBinaryTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/resourcebinary/ResourceBinaryTestCase.java
@@ -40,6 +40,8 @@ import java.net.URL;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class ResourceBinaryTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -53,7 +55,7 @@ public class ResourceBinaryTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(0)
-   public void display(@ArquillianResource URL deploymentURL) throws Exception
+   public void display() throws Exception
    {
       URL url = renderURL(deploymentURL, ResourceBinaryPortlet.class);
       driver.get(url.toString());
@@ -72,6 +74,7 @@ public class ResourceBinaryTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(1)
    public void check() throws Exception
    {

--- a/embed/src/test/java/org/gatein/pc/embed/resourcecookie/ResourceCookieTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/resourcecookie/ResourceCookieTestCase.java
@@ -38,6 +38,8 @@ import java.util.Map;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class ResourceCookieTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment()
    public static WebArchive deployment()
@@ -50,7 +52,7 @@ public class ResourceCookieTestCase extends AbstractTestCase
 
    @Test
    @RunAsClient
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, ResourceCookiePortlet.class);
       driver.get(url.toString());

--- a/embed/src/test/java/org/gatein/pc/embed/resourceerror/ResourceErrorTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/resourceerror/ResourceErrorTestCase.java
@@ -38,6 +38,8 @@ import java.net.URL;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class ResourceErrorTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -50,7 +52,7 @@ public class ResourceErrorTestCase extends AbstractTestCase
 
    @Test
    @RunAsClient
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, ResourceErrorPortlet.class);
       driver.get(url.toString());

--- a/embed/src/test/java/org/gatein/pc/embed/resourceheader/ResourceHeaderTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/resourceheader/ResourceHeaderTestCase.java
@@ -38,6 +38,8 @@ import java.util.Map;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class ResourceHeaderTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment()
    public static WebArchive deployment()
@@ -50,7 +52,7 @@ public class ResourceHeaderTestCase extends AbstractTestCase
 
    @Test
    @RunAsClient
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, ResourceHeaderPortlet.class);
       driver.get(url.toString());

--- a/embed/src/test/java/org/gatein/pc/embed/sendredirect/SendRedirectTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/sendredirect/SendRedirectTestCase.java
@@ -38,6 +38,8 @@ import java.util.Map;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class SendRedirectTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -50,7 +52,7 @@ public class SendRedirectTestCase extends AbstractTestCase
 
    @Test
    @RunAsClient
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, SendRedirectPortlet.class);
       driver.get(url.toString());

--- a/embed/src/test/java/org/gatein/pc/embed/setpublicrenderparameter/SetPublicRenderParameterTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/setpublicrenderparameter/SetPublicRenderParameterTestCase.java
@@ -39,6 +39,8 @@ import java.util.Collections;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class SetPublicRenderParameterTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -71,8 +73,9 @@ public class SetPublicRenderParameterTestCase extends AbstractTestCase
    WebDriver driver;
 
    @Test
+   @RunAsClient
    @InSequence(0)
-   public void ini() throws Exception
+   public void init() throws Exception
    {
       Assert.assertNull(SetPublicRenderParameterPortlet1.foo);
       Assert.assertNull(SetPublicRenderParameterPortlet2.foo);
@@ -81,7 +84,7 @@ public class SetPublicRenderParameterTestCase extends AbstractTestCase
    @Test
    @RunAsClient
    @InSequence(1)
-   public void setPortlet1(@ArquillianResource URL deploymentURL) throws Exception
+   public void setPortlet1() throws Exception
    {
       URL url = renderURL(deploymentURL, SetPublicRenderParameterPortlet1.class, SetPublicRenderParameterPortlet2.class);
       driver.get(url.toString());
@@ -90,6 +93,7 @@ public class SetPublicRenderParameterTestCase extends AbstractTestCase
    }
 
    @Test
+   @RunAsClient
    @InSequence(2)
    public void testPortlets()
    {

--- a/embed/src/test/java/org/gatein/pc/embed/unknownportlet/UnknowPortletTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/unknownportlet/UnknowPortletTestCase.java
@@ -35,6 +35,8 @@ import java.net.URL;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class UnknowPortletTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -46,7 +48,7 @@ public class UnknowPortletTestCase extends AbstractTestCase
 
    @Test
    @RunAsClient
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, FooPortlet.class);
       HttpURLConnection conn = (HttpURLConnection)url.openConnection();

--- a/embed/src/test/java/org/gatein/pc/embed/xmlescaping/XmlEscapingTestCase.java
+++ b/embed/src/test/java/org/gatein/pc/embed/xmlescaping/XmlEscapingTestCase.java
@@ -38,6 +38,8 @@ import java.util.regex.Pattern;
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
 public class XmlEscapingTestCase extends AbstractTestCase
 {
+   @ArquillianResource
+   URL deploymentURL;
 
    @Deployment
    public static WebArchive deployment()
@@ -47,7 +49,7 @@ public class XmlEscapingTestCase extends AbstractTestCase
 
    @Test
    @RunAsClient
-   public void testInteraction(@ArquillianResource URL deploymentURL) throws Exception
+   public void testInteraction() throws Exception
    {
       URL url = renderURL(deploymentURL, XmlEscapingPortlet.class);
       HttpURLConnection conn = (HttpURLConnection)url.openConnection();

--- a/pom.xml
+++ b/pom.xml
@@ -89,19 +89,26 @@
       <version.buildnumber.plugin>1.0</version.buildnumber.plugin>
 
       <!-- For testing -->
-      <version.junit>4.8.2</version.junit>
-      <version.arquillian>1.0.0.Final</version.arquillian>
-      <version.arquillian.tomcat>1.0.0.CR4</version.arquillian.tomcat>
+      <version.junit>4.12</version.junit>
+      <version.arquillian>1.1.12.Final</version.arquillian>
+      <version.arquillian.tomcat>1.0.0</version.arquillian.tomcat>
       <version.arquillian.jboss.weld>1.1.8.Final</version.arquillian.jboss.weld>
-      <version.shrinkwrap>1.0.0-cr-1</version.shrinkwrap>
-      <version.shrinkwrap.resolver>2.0.0-alpha-1</version.shrinkwrap.resolver>
-      <version.selenium>2.20.0</version.selenium>
-      <version.htmlunit>2.9</version.htmlunit>
-      <version.nekohtml>1.9.15</version.nekohtml>
-      <version.tomcat>7.0.30</version.tomcat>
+      <version.shrinkwrap>1.2.6</version.shrinkwrap>
+      <version.shrinkwrap.resolver>2.2.5</version.shrinkwrap.resolver>
+      <version.arquillian.drone>2.0.1.Final</version.arquillian.drone>
+      <version.arquillian.drone.selenium>2.53.1</version.arquillian.drone.selenium>
+      <version.selenium>2.53.1</version.selenium>
+      <version.htmlunit>2.21</version.htmlunit>
+      <version.guava>19.0</version.guava>
+      <version.xerces>2.11.0</version.xerces>
+      <version.tomcat>8.5.13</version.tomcat>
+      <version.servlet-api>3.1.0</version.servlet-api>
       <version.ecj>4.4.2</version.ecj>
+      <version.httpclient>4.5.2</version.httpclient>
+      <version.httpcore>4.4.4</version.httpcore>
       <version.commons-httpclient>3.1</version.commons-httpclient>
-      <version.commons-logging>1.1.1</version.commons-logging>
+      <version.commons-logging>1.2</version.commons-logging>
+      <version.commons-codec>1.10</version.commons-codec>
    </properties>
 
    <organization>
@@ -253,6 +260,16 @@
          </dependency>
 
          <!-- Dependencies for unit tests -->
+          <dependency>
+              <groupId>org.apache.httpcomponents</groupId>
+              <artifactId>httpclient</artifactId>
+              <version>${version.httpclient}</version>
+          </dependency>
+          <dependency>
+              <groupId>org.apache.httpcomponents</groupId>
+              <artifactId>httpcore</artifactId>
+              <version>${version.httpcore}</version>
+          </dependency>
          <dependency>
             <groupId>commons-httpclient</groupId>
             <artifactId>commons-httpclient</artifactId>
@@ -272,6 +289,11 @@
            <groupId>commons-logging</groupId>
            <artifactId>commons-logging</artifactId>
            <version>${version.commons-logging}</version>
+         </dependency>
+         <dependency>
+           <groupId>commons-codec</groupId>
+           <artifactId>commons-codec</artifactId>
+           <version>${version.commons-codec}</version>
          </dependency>
 
         <!-- Arquillian/Shrinkwrap stack -->
@@ -312,30 +334,24 @@
          </dependency>
 
         <!-- Drone -->
-        <dependency>
-          <groupId>org.jboss.arquillian.extension</groupId>
-          <artifactId>arquillian-drone-impl</artifactId>
-          <version>${version.arquillian}</version>
+        <dependency>                                      <!-- Selenium bom is optional - see note below -->
+          <groupId>org.jboss.arquillian.selenium</groupId>
+          <artifactId>selenium-bom</artifactId>
+          <version>${version.arquillian.drone.selenium}</version>
+          <type>pom</type>
+          <scope>import</scope>
         </dependency>
         <dependency>
           <groupId>org.jboss.arquillian.extension</groupId>
-          <artifactId>arquillian-drone-selenium</artifactId>
-          <version>${version.arquillian}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.jboss.arquillian.extension</groupId>
-          <artifactId>arquillian-drone-webdriver</artifactId>
-          <version>${version.arquillian}</version>
+          <artifactId>arquillian-drone-bom</artifactId>
+          <version>${version.arquillian.drone}</version>
+          <type>pom</type>
+          <scope>import</scope>
         </dependency>
         <dependency>
           <groupId>org.seleniumhq.selenium</groupId>
-          <artifactId>selenium-java</artifactId>
-          <version>${version.selenium}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.seleniumhq.selenium</groupId>
-          <artifactId>selenium-htmlunit-driver</artifactId>
-          <version>${version.selenium}</version>
+          <artifactId>htmlunit-driver</artifactId>
+          <version>${version.htmlunit}</version>
         </dependency>
         <dependency>
           <groupId>net.sourceforge.htmlunit</groupId>
@@ -343,15 +359,20 @@
           <version>${version.htmlunit}</version>
         </dependency>
         <dependency>
-          <groupId>net.sourceforge.nekohtml</groupId>
-          <artifactId>nekohtml</artifactId>
-          <version>${version.nekohtml}</version>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+          <version>${version.guava}</version>
+        </dependency>
+        <dependency>
+          <groupId>xerces</groupId>
+          <artifactId>xercesImpl</artifactId>
+          <version>${version.xerces}</version>
         </dependency>
 
         <!-- Arquillian Tomcat container -->
          <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-tomcat-embedded-7</artifactId>
+            <artifactId>arquillian-tomcat-embedded-8</artifactId>
             <version>${version.arquillian.tomcat}</version>
          </dependency>
          <dependency>
@@ -365,9 +386,9 @@
             <version>${version.tomcat}</version>
          </dependency>
          <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-logging-juli</artifactId>
-            <version>${version.tomcat}</version>
+           <groupId>javax.servlet</groupId>
+           <artifactId>javax.servlet-api</artifactId>
+           <version>${version.servlet-api}</version>
          </dependency>
          <dependency>
             <groupId>org.eclipse.jdt.core.compiler</groupId>

--- a/portlet/src/main/java/org/gatein/pc/portlet/impl/jsr168/DispatchedHttpServletRequest.java
+++ b/portlet/src/main/java/org/gatein/pc/portlet/impl/jsr168/DispatchedHttpServletRequest.java
@@ -27,10 +27,7 @@ import org.gatein.common.util.ParameterMap;
 import org.gatein.common.http.QueryStringParser;
 import org.gatein.pc.portlet.impl.jsr168.api.PortletRequestImpl;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletInputStream;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletRequest;
+import javax.servlet.*;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpServletRequestWrapper;
@@ -747,6 +744,23 @@ public abstract class DispatchedHttpServletRequest extends HttpServletRequestWra
          public final int read() throws IOException
          {
             return in.read();
+         }
+
+         @Override
+         public boolean isFinished()
+         {
+            return false;
+         }
+
+         @Override
+         public boolean isReady()
+         {
+            return false;
+         }
+
+         @Override
+         public void setReadListener(ReadListener readListener)
+         {
          }
       }
    }

--- a/portlet/src/main/java/org/gatein/pc/portlet/impl/jsr168/DispatchedHttpServletResponse.java
+++ b/portlet/src/main/java/org/gatein/pc/portlet/impl/jsr168/DispatchedHttpServletResponse.java
@@ -28,6 +28,7 @@ import org.gatein.pc.portlet.impl.jsr168.api.StateAwareResponseImpl;
 import javax.portlet.PortletResponse;
 import javax.portlet.MimeResponse;
 import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
@@ -230,6 +231,19 @@ public abstract class DispatchedHttpServletResponse extends HttpServletResponseW
       {
          return new ServletOutputStream()
          {
+            @Override
+            public boolean isReady()
+            {
+               return false;
+            }
+
+            @Override
+            public void setWriteListener(WriteListener writeListener)
+            {
+               // Ignore
+            }
+
+            @Override
             public void write(int b) throws IOException
             {
                // Ignore
@@ -357,6 +371,17 @@ public abstract class DispatchedHttpServletResponse extends HttpServletResponseW
                public void write(int b) throws IOException
                {
                   out.write(b);
+               }
+
+               @Override
+               public boolean isReady()
+               {
+                  return false;
+               }
+
+               @Override
+               public void setWriteListener(WriteListener writeListener)
+               {
                }
             };
          }

--- a/test/core/pom.xml
+++ b/test/core/pom.xml
@@ -51,6 +51,10 @@
          <artifactId>portlet-api</artifactId>
       </dependency>
       <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>javax.servlet-api</artifactId>
+      </dependency>
+      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
       </dependency>
@@ -63,10 +67,6 @@
       <dependency>
          <groupId>org.jboss.arquillian.junit</groupId>
          <artifactId>arquillian-junit-container</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.jboss.weld</groupId>
-         <artifactId>weld-core-test-arquillian</artifactId>
       </dependency>
       <dependency>
          <groupId>org.jboss.shrinkwrap</groupId>

--- a/test/core/src/main/java/org/gatein/pc/test/unit/AbstractEarTestCase.java
+++ b/test/core/src/main/java/org/gatein/pc/test/unit/AbstractEarTestCase.java
@@ -6,15 +6,12 @@ import org.gatein.pc.test.StringCodecTestCase;
 import org.gatein.pc.test.TestPortletApplicationDeployer;
 import org.gatein.pc.test.unit.protocol.Conversation;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.DependencyResolvers;
-import org.jboss.shrinkwrap.resolver.api.maven.MavenDependencyResolver;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.junit.Test;
 
-import java.io.File;
 import java.net.URL;
 
 /** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
@@ -64,10 +61,8 @@ public abstract class AbstractEarTestCase
       // Add dependencies
       // THIS IS COUPLED TO JBOSS7 BUT IT IS OK FOR NOW
       // AS ONLY JBOSS7 TESTING USES EAR
-      ear.addAsLibraries(DependencyResolvers.
-         use(MavenDependencyResolver.class).
-         loadEffectivePom("../dependencies/pom.xml").importAllDependencies().
-         resolveAsFiles());
+      ear.addAsLibraries(Maven.resolver().loadPomFromFile("../dependencies/pom.xml")
+              .importRuntimeAndTestDependencies().resolve().withTransitivity().asFile());
 
       //
       return ear;

--- a/test/core/src/test/resources/arquillian.xml
+++ b/test/core/src/test/resources/arquillian.xml
@@ -3,6 +3,9 @@
             xsi:schemaLocation="
         http://jboss.org/schema/arquillian
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+    <engine>
+        <property name="deploymentExportPath">target/deployments</property>
+    </engine>
     <container qualifier="jbossas-managed" default="true">
         <configuration>
             <property name="jbossHome">${JBOSS_HOME}</property>

--- a/test/core/src/test/resources/ha/test-session-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/ha/test-session-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<web-app version="2.4"
-         xmlns="http://java.sun.com/xml/ns/j2ee"
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <listener>
       <listener-class>org.gatein.pc.test.portlet.session.SessionSequenceBuilder</listener-class>
    </listener>

--- a/test/core/src/test/resources/info/test-info-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/info/test-info-war/WEB-INF/web.xml
@@ -22,8 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
 </web-app>

--- a/test/core/src/test/resources/jsr168/api/actionrequest-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/api/actionrequest-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/api/actionresponse-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/api/actionresponse-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/api/portalcontext-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/api/portalcontext-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/api/portletconfig-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/api/portletconfig-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/api/portletcontext-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/api/portletcontext-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <display-name>PortletContext WebApp</display-name>
    <servlet>
      <servlet-name>PortletServlet</servlet-name>

--- a/test/core/src/test/resources/jsr168/api/portletmode-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/api/portletmode-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/api/portletpreferences-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/api/portletpreferences-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/api/portletsession-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/api/portletsession-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/api/portletsessionutil-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/api/portletsessionutil-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/api/portleturl-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/api/portleturl-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/api/renderrequest-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/api/renderrequest-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-    "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-    "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/api/renderresponse-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/api/renderresponse-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/api/windowstate-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/api/windowstate-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/ext/expiringcache-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/ext/expiringcache-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/ext/neverexpiringcache-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/ext/neverexpiringcache-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/ext/nocache-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/ext/nocache-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/ext/portletconfig-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/ext/portletconfig-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/ext/portletmode-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/ext/portletmode-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/ext/portletrequests-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/ext/portletrequests-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/ext/portletresponses-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/ext/portletresponses-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/ext/preferences-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/ext/preferences-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/ext/taglib-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/ext/taglib-war/WEB-INF/web.xml
@@ -22,9 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
       <servlet-name>UniversalServletA</servlet-name>
       <servlet-class>org.gatein.pc.test.unit.web.UTS1</servlet-class>

--- a/test/core/src/test/resources/jsr168/tck/basic-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/tck/basic-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<web-app version="2.4"
-         xmlns="http://java.sun.com/xml/ns/j2ee"
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <listener>
       <listener-class>org.gatein.pc.test.unit.basictests.BasicTestSequenceBuilder</listener-class>
    </listener>

--- a/test/core/src/test/resources/jsr168/tck/dispatcher-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/tck/dispatcher-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
       <servlet-name>UniversalServletA</servlet-name>
       <servlet-class>org.gatein.pc.test.unit.web.UTS1</servlet-class>

--- a/test/core/src/test/resources/jsr168/tck/portletconfig-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/tck/portletconfig-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/tck/portletcontext-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/tck/portletcontext-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
       <servlet-name>UniversalServletA</servlet-name>
       <servlet-class>org.gatein.pc.test.unit.web.UTS1</servlet-class>

--- a/test/core/src/test/resources/jsr168/tck/portletinterface-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/tck/portletinterface-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
       <servlet-name>universalServletA</servlet-name>
       <servlet-class>org.gatein.pc.test.unit.web.UTS1</servlet-class>

--- a/test/core/src/test/resources/jsr168/tck/portletmode-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/tck/portletmode-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/tck/portletrequests-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/tck/portletrequests-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/tck/portletresponses-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/tck/portletresponses-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
       <servlet-name>UniversalServletA</servlet-name>
       <servlet-class>org.gatein.pc.test.unit.web.UTS1</servlet-class>

--- a/test/core/src/test/resources/jsr168/tck/portleturl-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/tck/portleturl-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/tck/preferences-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/tck/preferences-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr168/tck/windowstates-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr168/tck/windowstates-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/api/event-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/api/event-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/api/portleturl-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/api/portleturl-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/ext/cache-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/ext/cache-war/WEB-INF/web.xml
@@ -22,11 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<web-app
-   xmlns="http://java.sun.com/xml/ns/j2ee"
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
-   version="2.4">
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/ext/dispatcher-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/ext/dispatcher-war/WEB-INF/web.xml
@@ -22,11 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<web-app
-   xmlns="http://java.sun.com/xml/ns/j2ee"
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
-   version="2.4">
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
 
    <filter>
       <filter-name>IncludeURLPatternFilter</filter-name>

--- a/test/core/src/test/resources/jsr286/ext/event-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/ext/event-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/ext/eventsupport-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/ext/eventsupport-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/ext/portletcontext-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/ext/portletcontext-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/ext/portletfilter-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/ext/portletfilter-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/ext/portletinterface-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/ext/portletinterface-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/ext/portletmode-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/ext/portletmode-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/ext/portletrequests-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/ext/portletrequests-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/ext/portletresponses-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/ext/portletresponses-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/tck/dispatcher-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/tck/dispatcher-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
 
    <servlet>
       <servlet-name>UniversalServletA</servlet-name>

--- a/test/core/src/test/resources/jsr286/tck/event-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/tck/event-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/tck/eventnonamespace-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/tck/eventnonamespace-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/tck/portletconfig-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/tck/portletconfig-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/tck/portletconfignonamespace-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/tck/portletconfignonamespace-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/tck/portletfilter-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/tck/portletfilter-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/tck/portletrequests-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/tck/portletrequests-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/tck/portleturl-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/tck/portleturl-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/tck/resourceserving-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/tck/resourceserving-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/tck/stateawareresponse-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/tck/stateawareresponse-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/tck/taglib-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/tck/taglib-war/WEB-INF/web.xml
@@ -22,9 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/core/src/test/resources/jsr286/tck/userinformation-war/WEB-INF/web.xml
+++ b/test/core/src/test/resources/jsr286/tck/userinformation-war/WEB-INF/web.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.                  ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<!DOCTYPE web-app PUBLIC
-   "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-   "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
    <servlet>
      <servlet-name>PortletServlet</servlet-name>
      <servlet-class>org.gatein.pc.test.unit.PortletTestServlet</servlet-class>

--- a/test/servers/tomcat7/pom.xml
+++ b/test/servers/tomcat7/pom.xml
@@ -31,7 +31,7 @@
       <!-- Arquillian container -->
       <dependency>
         <groupId>org.jboss.arquillian.container</groupId>
-        <artifactId>arquillian-tomcat-embedded-7</artifactId>
+        <artifactId>arquillian-tomcat-embedded-8</artifactId>
       </dependency>
       <dependency>
         <groupId>org.apache.tomcat.embed</groupId>
@@ -42,16 +42,16 @@
         <artifactId>tomcat-embed-jasper</artifactId>
       </dependency>
       <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-logging-juli</artifactId>
-      </dependency>
-      <dependency>
         <groupId>org.eclipse.jdt.core.compiler</groupId>
         <artifactId>ecj</artifactId>
       </dependency>
       <dependency>
         <groupId>javax.servlet.jsp</groupId>
         <artifactId>jsp-api</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>javax.servlet-api</artifactId>
       </dependency>
 
    </dependencies>


### PR DESCRIPTION
This PR :
* upgrades Arquillian libs and uses Tomcat 8 embedded container
* disables the jar scanning for manifest files (as in the distributions)
* upgrades the wci dependency to use the new tomcat 8 version
* disables 10 tests because of a Tomcat bugs. These 10 tests fail because of the following bug in Tomcat : https://bz.apache.org/bugzilla/show_bug.cgi?id=60882. This bug will be fixed in Tomcat 8.5.13, so the tests must be re-enabled when we will do the upgrade.